### PR TITLE
added voronoi mode, changed method for perlin (now works with bobs ores)

### DIFF
--- a/maps/dangOreus.lua
+++ b/maps/dangOreus.lua
@@ -2,6 +2,7 @@
 global.STARTING_RADIUS = settings.global["starting radius"].value
 global.EASY_ORE_RADIUS = settings.global["simple ore radius"].value
 global.DANGORE_MODE = settings.global["dangore mode"].value
+global.V_SCALE_FACTOR = settings.global["voronoi scale factor"].value
 
 --dangOreus, a scenario by Mylon
 --MIT Licensed
@@ -10,10 +11,18 @@ require "perlin" --Perlin Noise.
 
 ORE_SCALING = 0.78 --Exponent for ore amount.
 LINEAR_SCALAR = 12 -- For ore amount.
+XFER_FACTOR = 3.0 -- ERF() factor, for non-uniform perlin transfer
 --DANGORE_MODE = 2 -- 1 == Random, 2 == Perlin
 
 if MODULE_LIST then
 	module_list_add("dangOreus")
+end
+
+
+function clamp(min, max, v) 
+    if v < min then return min end
+    if v > max then return max end
+    return v
 end
 
 --Sprinkle ore everywhere
@@ -104,6 +113,15 @@ function gOre(event)
     end
     global.ore_chunks[chunkx][chunky] = {type=chunk_type, biased=biased}
 
+    local  ore_list = global.ORE_LIST;
+
+    local function transferFunc(f) 
+        f = math.tanh(2 * XFER_FACTOR * f * (1.0 + 0.08943 * f * f * XFER_FACTOR * XFER_FACTOR) / math.sqrt(3.14159))
+        f = (5000.0 + 5000.0 * f) / 10000.0
+        f = f - 0.5
+        return 2.0 * f
+    end
+
     for x = event.area.left_top.x, event.area.left_top.x + 31 do
         for y = event.area.left_top.y, event.area.left_top.y + 31 do
             local bbox = {{ x, y}, {x+0.5, y+0.5}}
@@ -111,21 +129,21 @@ function gOre(event)
                 local amount = (x^2 + y^2)^ORE_SCALING / LINEAR_SCALAR
                 if x^2 + y^2 >= global.STARTING_RADIUS^2 then
                     --Build the ore list.  Uranium can only appear in uranium chunks.
-                    local ore_list = {}
-                    for k, v in pairs(global.easy_ore_list) do
-                        table.insert(ore_list, v)
-                    end
-                    if not (chunk_type == "random") then
-                        --Build the ore list.  non-baised chunks get 3 instances, biased chunks get 6.  Except uranium, which has no default instance in the table.
-                        table.insert(ore_list, chunk_type)
-                        --table.insert(ore_list, chunk_type)
-                        if biased then
-                            table.insert(ore_list, chunk_type)
-                            table.insert(ore_list, chunk_type)
-                            --table.insert(ore_list, chunk_type)
-                        end
-                        --game.print(serpent.line(ore_list))
-                    end
+                    --local ore_list = {}
+                    -- for k, v in pairs(global.easy_ore_list) do
+                    --     table.insert(ore_list, v)
+                    -- end
+                    -- if not (chunk_type == "random") then
+                    --     --Build the ore list.  non-baised chunks get 3 instances, biased chunks get 6.  Except uranium, which has no default instance in the table.
+                    --     table.insert(ore_list, chunk_type)
+                    --     --table.insert(ore_list, chunk_type)
+                    --     if biased then
+                    --         table.insert(ore_list, chunk_type)
+                    --         table.insert(ore_list, chunk_type)
+                    --         --table.insert(ore_list, chunk_type)
+                    --     end
+                    --     --game.print(serpent.line(ore_list))
+                    -- end
 
                     local type
                     if global.DANGORE_MODE == 1 then
@@ -147,13 +165,14 @@ function gOre(event)
                         --     type = "uranium-ore"
                         -- end
 
-                        --Using auto threshholds
-                        local noise = perlin.noise(x,y)
-                        for k,v in pairs(global.perlin_ore_list) do
-                            if noise < v[2] then
-                                type = v[1]
-                                break
-                            end
+                        local noise
+                        if global.DANGORE_MODE == 3 then
+                            noise = voronoi(x, y)                            
+                            type = ore_list[clamp(1, #ore_list, math.floor(#ore_list * (noise / 2 + 0.5)) + 1)]
+                        else
+                            noise = perlin.noise(x,y)
+                            noise = transferFunc(noise)
+                            type = ore_list[clamp(1, #ore_list, math.floor(#ore_list * (noise / 2 + 0.5)) + 1)]
                         end
                         if not type then
                             local _
@@ -176,6 +195,75 @@ function gOre(event)
 			end
 		end
 	end
+end
+
+
+--
+-- some tweakable factors for the voronoi function
+--
+RING_SIZE = 200.0    -- width of rings
+WOBBLE_DEPTH = 40.0  -- depth to "blend" the rings to
+WOBBLE_FACTOR = 6.0  -- number of revolutions to use
+WOBBLE_SCALE = 0.7   -- how to scale the number of revolutions based on the ring number
+
+function voronoi(x, y) 
+    local function dot(vx, vy, ux, uy) 
+        return vx * ux + vy * uy
+    end
+
+    local function fract(v) 
+        -- Is there a more sane way to do this?
+        local a, b = math.modf(v)
+        return b
+    end
+
+    local function randAt(px, py) 
+        local rv = global.rand_vecs
+        local a = {dot(px, py, rv[1], rv[2]), dot(px, py, rv[3], rv[4])}
+        a[1] = fract(math.sin(a[1]) * rv[5])
+        a[2] = fract(math.sin(a[2]) * rv[5])
+        return a
+    end
+
+    --
+    -- transform input coordinate, and determine a scale factor
+    --
+    local scaleFactor = global.V_SCALE_FACTOR
+    local ring = math.floor(math.sqrt(x * x + y * y) / RING_SIZE)
+    local ang = math.atan2(x, y)
+    local gx = x + math.sin(ang * WOBBLE_FACTOR * (1 + ring * WOBBLE_SCALE)) * WOBBLE_DEPTH -- perturb coords used for actual ring determination
+    local gy = y + math.cos(ang * WOBBLE_FACTOR * (1 + ring * WOBBLE_SCALE)) * WOBBLE_DEPTH
+    ring = math.floor(math.sqrt(gx * gx + gy * gy) / RING_SIZE)
+    local scale = clamp(4.0, 50.0, ring * 10.0) * scaleFactor
+    local offx = randAt(scale, 0)[1] * 50.0 -- prevent the same random layout repeating on higher scale sections by shifting it a bit
+    x = x / scale + offx
+    y = y / scale
+
+    --
+    -- cell noise
+    --
+    local close = {}
+    local ix, fx = math.modf(x)
+    local iy, fy = math.modf(y)
+    local best = 100
+    for ny = -1, 1 do 
+        for nx = -1, 1 do 
+            local p = randAt(ix + ny, iy + nx)
+            local dx = ny + p[1] / 1.8 - fx
+            local dy = nx + p[2] / 1.8 - fy
+            local d = dx * dx + dy * dy
+            if d < best then
+                best = d
+                close[1] = ix + ny
+                close[2] = iy + nx
+            end            
+        end
+    end
+
+    --
+    -- pick an ore type based on this cell's centroid 
+    --
+    return randAt(close[1], close[2])[1]
 end
 
 --Auto-destroy non-mining drills.
@@ -290,6 +378,13 @@ function divOresity_init()
     global.ore_chunks = {}
 
     global.perlin_ore_list = {}
+    local rv = {}
+    rv[1] = math.random() * 200.0
+    rv[2] = math.random() * 200.0
+    rv[3] = math.random() * 200.0
+    rv[4] = math.random() * 200.0
+    rv[5] = math.random() * 50000.0
+    global.rand_vecs = rv
 
     --These are depreciated.
     -- global.easy_ores = {}
@@ -404,79 +499,25 @@ function divOresity_init()
         end
     end
 
-    --Debug
-    --log(serpent.block(ore_ranking_raw))
-
-    --Calculate ore distribution from 0 to 1.
-    local last_key = 0
-    local ore_ranking_size = 0 --Essentially #ore_ranking_raw
-    for k,v in pairs(ore_ranking_raw) do
-        local key = last_key + v.amount / ore_total
-        last_key = key
-
-        if key == 1 then key = 0.9999999 end
-        --ore_ranking[key] = v.name
-        table.insert(ore_ranking, {v.name, key})
-        --ore_ranking_size = ore_ranking_size + 1
-        --Debug
-        --log("Ore: " .. v.name .. " portion: " .. key)
-        --According to this, at this stage, uranium should be 2% of all ore.
-    end
-
-    --This next bit requires a lerp
-    --Returns x3
-    local function lerp(x1, x2, dy, y3)
-        return y3 * (x2-x1)/dy + x1
-    end
-
-    --Now do a pass to scale these numbers according to perlin.MEASURED distribution
-    local last_ranking_key = 0
-    last_key = -1
-    local previous_iter = -1
-    local count = 0
-    for k,v in pairs(ore_ranking) do
-        --local range = k - last_ranking_key -- This is the percentage that should appear of this ore type
-        local range = v[2] - last_ranking_key -- This is the percentage that should appear of this ore type
-        last_ranking_key = v[2]
-        local measured_sum = 0 -- This is the range that our perlin steps cover, from last_key to n
-        --log("For ore " .. v[1] .. " using range " .. range)
-        -- count = count + 1 -- This is so we do something special on the last one.  Rounding errors may cause the last ore to not be inserted otherwise.
-        --local perlin_key
-        --The last ore will never get used.  Let's determine if we're at the end of the table and write the last key there.
-        for n, p in pairs(perlin.MEASURED) do
-            --Skip keys we've already iterated over
-            if n > last_key then
-                measured_sum = measured_sum + p
-                --If I were to get fancy, I could add a LERP here for finer control of perlin_ore_list keys.
-                --if count < ore_ranking_size then            
-                    if measured_sum > range then
-                        --log("measured sum is " .. measured_sum .. " and key range is " .. n - last_key)
-                        local x3 = lerp(previous_iter, n, p, range - (measured_sum - p) )
-                        table.insert(global.perlin_ore_list, {v[1], x3})
-                        --perlin_ore_list[n] = name
-                        last_key = n
-                        previous_iter = n
-                        break
-                    end
-                --else
-                --    perlin_ore_list[0.9999999] = v
-                    --game.print(0.88 - n .. "," .. range) --Debug.
-                    --break
-                --end
-                previous_iter = n
-            end
+    --
+    -- Generate a lookup table of 1000 slots, distributed correctly so
+    -- they respect the ratios of ore the autoplacer wants to place
+    --
+    local ore_list = {}
+    local f = 0.0
+    local j = 1
+    for i = 1, 1000 do 
+        local current = ore_ranking_raw[j]        
+        table.insert(ore_list, current.name)
+        if f > current.amount then
+            j = j + 1
+            f = f - current.amount
         end
-
-        --Are we still here?  Insert at the last key.
-        if not global.perlin_ore_list[k] then
-            table.insert(global.perlin_ore_list, {v[1], 1})
-        end
-        
-        --perlin_ore_list[0.9999999] = v
-
-        -- perlin_ore_list[math.abs(k)^0.5 * sign] = v
-        -- perlin_ore_list[k] = v
+        f = f + ore_total / 1000.0
     end
+
+    global.ORE_LIST = ore_list
+
 
     -- For debugging
     --log(serpent.block(perlin_ore_list))


### PR DESCRIPTION
Added a 3rd generation mode, "Voronoi".  Requires these changes to the actual mod as well:

**settings.lua**:
```
    {
        type = "int-setting",
        name = "dangore mode",
        setting_type = "runtime-global",
        default_value = 3,
        minimum_value = 1,
        maximum_value = 3,
        order = "04"
    },
    {
        type = "double-setting",
        name = "voronoi scale factor",
        setting_type = "runtime-global",
        default_value = 3.0,
        minimum_value = 0.1,
        maximum_value = 50.0,
        order = "05"
    }
```

**locale.cfg**:
```
[mod-setting-name]
starting radius=starting radius
simple ore radius=simple ore radius
easy mode=Easy mode
dangore mode=Ore generation mode
voronoi scale factor=Scale Factor in Voronoi Mode


[mod-setting-description]
starting radius=Starting area radius.  This area will be free of ores.
simple ore radius=Uranium (or other fluid-required ores) will not be generated within this radius.
easy mode=Allow building belts and power poles on ore.
dangore mode=1 is semirandom, 2 is perlin noise mode, 3 is Voronoi/Cell noise. 
voronoi scale factor=Larger numbers will make features larger
```

Also rewritten the way the Perlin generator works, it now uses a lookup table and a transfer function to map the Gaussian distribution of the Perlin generator onto a uniform one.  It's much faster, and doesn't suffer from the over-shoot that was breaking mods with a lot of different ore types (like zinc was missing from bobsores)